### PR TITLE
Fix csl title mappings

### DIFF
--- a/src/ItemMaps.js
+++ b/src/ItemMaps.js
@@ -268,7 +268,7 @@ ItemMaps.cslNameMap = {
 };
 
 ItemMaps.cslFieldMap = {
-	'title': ['title'],
+	'title': ['title', 'nameOfAct', 'caseName', 'subject'],
 	'container-title': ['publicationTitle',  'reporter', 'code'], /* reporter and code should move to SQL mapping tables */
 	'collection-title': ['seriesTitle', 'series'],
 	'collection-number': ['seriesNumber'],

--- a/src/ItemMaps.js
+++ b/src/ItemMaps.js
@@ -328,7 +328,7 @@ ItemMaps.cslTypeMap = {
 	'case': 'legal_case',
 	'hearing': 'bill',                // ??
 	'patent': 'patent',
-	'statute': 'bill',                // ??
+	'statute': 'legislation',
 	'email': 'personal_communication',
 	'map': 'map',
 	'blogPost': 'webpage',


### PR DESCRIPTION
The `cslItem()` method was returning Zotero `statute` items as CSL type `bill`, with no title.

(I'm not sure if this is the right fix for the field mappings. If there is code in `libZoteroJS` meant to reflect the base field mappings from Zotero SQL, that would be a better place to pick those up -- but this got things working again locally, at least.)
